### PR TITLE
Get the radius from properties

### DIFF
--- a/samples/scallopedBorder/worklet.js
+++ b/samples/scallopedBorder/worklet.js
@@ -5,9 +5,7 @@ if (typeof registerPaint !== 'undefined') {
     }
   
     paint(ctx, size, properties) {
-      // why doesn't this work?
-      // const radius = properties.get('--extra-scallopRadius')
-      const radius = 10
+      const radius = properties.get('--extra-scallopRadius').value
       const scallopWeight = properties.get('--extra-scallopWeight')
       const color = properties.get('--extra-scallopColor')
       const height = size.height


### PR DESCRIPTION
You need to get the value of the CSSUnitValue object `properties.get('--extra-scallopRadius').value`.
I think that this it's happening because you're doing a Math operation with this var in the next lines.