### PR TITLE
Extract the extra.css version to package.json

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -43,5 +43,8 @@
   },
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
+  },
+  "extras": {
+    "version": "1.2.0"
   }
 }

--- a/site/src/components/Demos/Confetti/index.js
+++ b/site/src/components/Demos/Confetti/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import Card from '../../Card'
 import CardLinks from '../../CardLinks'
 import CardStyle from '../../Card/style.module.css'
+import pjson from '../../../../package.json'
 
 export default class Confetti extends Component {
   state = {
@@ -12,7 +13,7 @@ export default class Confetti extends Component {
 
   componentDidMount () {
     const workletScript = document.createElement("script")
-    workletScript.src = `https://unpkg.com/extra.css@1.2.0/confetti.js`
+    workletScript.src = `https://unpkg.com/extra.css@${pjson.extras.version}/confetti.js`
     document.body.appendChild(workletScript)
   }
 

--- a/site/src/components/Demos/CrossOut/index.js
+++ b/site/src/components/Demos/CrossOut/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import Card from '../../Card'
 import CardStyle from '../../Card/style.module.css'
 import CardLinks from '../../CardLinks'
-
+import pjson from '../../../../package.json'
 export default class CrossOut extends Component {
   state = {
     spread: 100,
@@ -12,7 +12,7 @@ export default class CrossOut extends Component {
 
   componentDidMount () {
     const workletScript = document.createElement("script")
-    workletScript.src = `https://unpkg.com/extra.css@1.2.0/crossOut.js`
+    workletScript.src = `https://unpkg.com/extra.css@${pjson.extras.version}/crossOut.js`
     document.body.appendChild(workletScript)
   }
 

--- a/site/src/components/Demos/ScallopedBorder/index.js
+++ b/site/src/components/Demos/ScallopedBorder/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import Card from '../../Card'
 import CardLinks from '../../CardLinks'
 import CardStyle from '../../Card/style.module.css'
-
+import pjson from '../../../../package.json'
 export default class ScallopedBorder extends Component {
   state = {
     radius: 9,
@@ -12,7 +12,7 @@ export default class ScallopedBorder extends Component {
 
   componentDidMount () {
     const workletScript = document.createElement("script")
-    workletScript.src = `https://unpkg.com/extra.css@1.2.0/scallopedBorder.js`
+    workletScript.src = `https://unpkg.com/extra.css@${pjson.extras.version}/scallopedBorder.js`
     document.body.appendChild(workletScript)
   }
 

--- a/site/src/components/Demos/Sparkles/index.js
+++ b/site/src/components/Demos/Sparkles/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import Card from '../../Card'
 import CardLinks from '../../CardLinks'
 import CardStyle from '../../Card/style.module.css'
-
+import pjson from '../../../../package.json'
 export default class Sparkles extends Component {
   state = {
     number: 30,
@@ -14,7 +14,7 @@ export default class Sparkles extends Component {
 
   componentDidMount () {
     const workletScript = document.createElement("script")
-    workletScript.src = `https://unpkg.com/extra.css@1.2.0/sparkles.js`
+    workletScript.src = `https://unpkg.com/extra.css@${pjson.extras.version}/sparkles.js`
     document.body.appendChild(workletScript)
   }
 

--- a/site/src/components/Demos/SuperUnderline/index.js
+++ b/site/src/components/Demos/SuperUnderline/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import Card from '../../Card'
 import CardLinks from '../../CardLinks'
 import CardStyle from '../../Card/style.module.css'
-
+import pjson from '../../../../package.json'
 export default class SuperUnderline extends Component {
   state = {
     number: 3,
@@ -13,7 +13,7 @@ export default class SuperUnderline extends Component {
 
   componentDidMount () {
     const workletScript = document.createElement("script")
-    workletScript.src = `https://unpkg.com/extra.css@1.2.0/superUnderline.js`
+    workletScript.src = `https://unpkg.com/extra.css@${pjson.extras.version}/superUnderline.js`
     document.body.appendChild(workletScript)
   }
 


### PR DESCRIPTION
To improve the updates of **extra.css** version on demos, we extract the hardcoded version to `package.json`.
```
...
  "extras": {
    "version": "1.2.0"
  }
```

And then, import and use it into template literals.
```
import pjson from '../../../../package.json'

...

workletScript.src = `https://unpkg.com/extra.css@${pjson.extras.version}/crossOut.js`
```